### PR TITLE
remove warnings and enable build on newer gcc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ STATIC=
 #PROFILE=-pg
 PROFILE=
 
-COPTS=-c -Wall -Wextra -std=c11 -DOS_LINUX $(PROFILE) -flto
+COPTS=-c -Wall -Wextra -std=c11 -DOS_LINUX -D_XOPEN_SOURCE=700 $(PROFILE) -flto
 ifeq ($(OPSYS),macos)
 COPTS+=-Oz -I/usr/local/opt/readline/include
 else

--- a/src/pdclinux.c
+++ b/src/pdclinux.c
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 #include <readline/readline.h>
 #include <readline/history.h>
@@ -548,7 +549,7 @@ PUBLIC void sys_sys_exp(struct exp_list *exproot, void **result, enum
                                   "SYS(sbrk) takes no further parameters");
 
                 *result = cell_alloc(INT_CPOOL);
-		**( (long **) result )=(long)sbrk(0);
+		**( (long **) result )=(long)malloc(0);
                 *type = V_INT;
 	} else if (strcmp(cmd, "now") == 0) {
                 if (exproot->next)


### PR DESCRIPTION
I added a flag and changed a few bits to make it build on a recent gcc on Linux.

It was fun to see Comal-80 again after all these years!